### PR TITLE
feat(deps): upgrade bucket4j-core to major version 8.0.1

### DIFF
--- a/application/user-api/build.gradle
+++ b/application/user-api/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
     
     // Rate limiting (API 호출 제한)
-    implementation 'com.github.vladimir-bukhtoyarov:bucket4j-core'
+    implementation 'com.bucket4j:bucket4j-core'
     
     // Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ subprojects {
             dependency 'com.querydsl:querydsl-apt:5.1.0'
             dependency 'com.vladmihalcea:hibernate-types-60:2.21.1'
             dependency 'org.redisson:redisson-spring-boot-starter:3.50.0'
-            dependency 'com.github.vladimir-bukhtoyarov:bucket4j-core:7.6.0'
+            dependency 'com.bucket4j:bucket4j-core:8.0.1'
             dependency 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
             dependency 'com.opencsv:opencsv:5.12.0'
             dependency 'org.apache.poi:poi-ooxml:5.4.1'


### PR DESCRIPTION
## Summary
Upgrades bucket4j-core from 7.6.0 to 8.0.1, handling breaking changes from the major version update.

## Breaking Changes Handled 🚨
- **GroupId migration**: `com.github.vladimir-bukhtoyarov` → `com.bucket4j`
- **Version jump**: 7.6.0 → 8.0.1 (major version)
- **JDK requirement**: Now requires JDK 11+ (compatible with our JDK 17)

## Changes Made
### Gradle Dependencies Updated
- `build.gradle`: Updated dependency management GroupId and version
- `application/user-api/build.gradle`: Updated implementation dependency GroupId

### No Java Code Changes Required ✅
- bucket4j is not currently used in the codebase (dependency only)
- No imports or API calls to update
- Future usage will use the new `com.bucket4j.*` package structure

## Testing Results
- ✅ **Clean build successful**
- ✅ **All modules compile without errors**  
- ✅ **No dependency conflicts detected**
- ✅ **JDK 17 compatibility confirmed**

## Risk Assessment
- **Overall Risk**: **LOW** (despite major version)
- **Reason**: No actual code usage means no runtime impact
- **Breaking Changes**: Fully handled in dependency declarations
- **Future-proof**: Ready for when rate limiting features are implemented

## bucket4j 8.0.1 New Features
- Verbose API fixes
- Java 11+ baseline (compatible with our JDK 17)
- Improved GroupId organization under `com.bucket4j`

## Migration Notes for Future Development
When implementing rate limiting features, use:
```java
// NEW (8.0.1+)
import com.bucket4j.Bucket;
import com.bucket4j.Bandwidth;

// OLD (7.x) - no longer valid
// import com.github.vladimir.bukhtoyarov.bucket4j.Bucket;
```

## Dependabot PR Resolved
- Closes #9 (bucket4j-core 7.6.0 → 8.0.1)

🤖 Generated with [Claude Code](https://claude.ai/code)